### PR TITLE
Added Functionality to read cnc_sysinfo

### DIFF
--- a/examples/focas_sysinfo_fetch.py
+++ b/examples/focas_sysinfo_fetch.py
@@ -12,8 +12,9 @@ focas = ch.Focas(
 # Get the program name
 response = focas.cnc_sysinfo()
 print('Cnc additianl info:', response.addinfo)
-print('Cnc Series', response.series)
-print('Cnc Max axis:', response.max_axis)
+print('Cnc Type', response.cnc_type)
+print("Cnc Machine type", response.mt_type)
+print('Cnc Numvber of Controlled axis:', response.axis)
 
 # Disconnect from the machine
 focas = None

--- a/examples/focas_sysinfo_fetch.py
+++ b/examples/focas_sysinfo_fetch.py
@@ -1,0 +1,19 @@
+
+
+import chattertools as ch
+
+# Create the focas object and connect to the machine
+focas = ch.Focas(
+    ip='192.168.1.132', # IP of the machine     * Required
+    port=8193,      # Port number           Default: 8193
+    timeout=3       # Timeout in seconds    Default: 3
+)
+
+# Get the program name
+response = focas.cnc_sysinfo()
+print('Cnc additianl info:', response.addinfo)
+print('Cnc Series', response.series)
+print('Cnc Max axis:', response.max_axis)
+
+# Disconnect from the machine
+focas = None

--- a/src/chattertools/focas.py
+++ b/src/chattertools/focas.py
@@ -233,6 +233,34 @@ class Focas:
         self._validateResponse(result)
 
         return True
+    
+    def cnc_sysinfo(self):
+        """ Reads the system information of CNC. The various information is stored in each member of "ODBSYS".
+        Args:
+            None
+        Omitted Fanuc Args:
+            handle: The handle
+            ODBSYS: Structure to store the system information
+        Returns:
+            odbsys(Class)
+                addinfo (int)
+                max_axis (int)
+                cnc_type (str)
+                mt_type (str)
+                series (str)
+                version (str)
+                axes (str)
+            """
+        f = self.fwlib.cnc_sysinfo
+        f.argtypes = [c_ushort,POINTER(ODBSYS)]
+        f.restype = c_short
+
+        _sys_info = ODBSYS()
+
+        result = f(self.handle,byref(_sys_info))
+        self._validateResponse(result)
+
+        return _sys_info.getPyObj()
 
     @staticmethod
     def decodeFanucMacro(input: ODBM):

--- a/src/chattertools/focas_structs.py
+++ b/src/chattertools/focas_structs.py
@@ -136,3 +136,32 @@ class odbalmmsg():
 
     def __str__(self):
         return f'odbalmmsg(alm_no={self.alm_no}, type={self.type}, axis={self.axis}, msg_len={self.msg_len}, alm_msg={self.alm_msg})'
+    
+class ODBSYS(ctypes.Structure):
+    '''Used with cnc_sysinfo  MS'''
+    _fields_ = [
+        ('addinfo',ctypes.c_short),
+        ('max_axis', ctypes.c_short),
+        ('cnc_type', ctypes.c_char * 2),
+        ('mt_type', ctypes.c_char * 2),
+        ('series', ctypes.c_char * 4),
+        ('version', ctypes.c_char * 4),
+        ('axis', ctypes.c_char * 2)
+    ]
+
+    def getPyObj(self):
+        return odbsys(self.addinfo, self.max_axis, self.cnc_type, self.mt_type, self.series, self.version, self.axis)
+    
+class odbsys():
+    def __init__(self, addinfo, max_axis, cnc_type, mt_type, series, version, axis):
+            self.addinfo = int(addinfo)
+            self.max_axis = int(max_axis)
+            self.cnc_type = cnc_type.decode('ascii').strip()
+            self.mt_type = mt_type.decode('ascii').strip()
+            self.series = series.decode('ascii').strip()
+            self.version = version.decode('ascii').strip()
+            self.axis = axis.decode('ascii').strip() #prefer to conver to int but expected return is string
+    
+    def __str__(self) -> str:
+        return f'odbsys(addinfo={self.addinfo}, max_axis={self.max_axis}, cnc_type={self.cnc_type}, mt_type={self.mt_type}, series={self.series}, version={self.version}, axis={self.axis})'
+    

--- a/tests/test_focas.py
+++ b/tests/test_focas.py
@@ -6,7 +6,7 @@ class TestFocas(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.focas = ch.Focas(ip='10.0.2.51', port=8193, timeout=3)
+        cls.focas = ch.Focas(ip='192.168.1.132', port=8193, timeout=3)
 
     def test_cnc_allclibhndl3(self):
         self.assertTrue(self.focas.handle != 0)
@@ -41,6 +41,10 @@ class TestFocas(unittest.TestCase):
         self.focas.cnc_wrmacro(MACRO_VAR, TEST_VALUE)
         macroRead = self.focas.cnc_rdmacro(MACRO_VAR)
         self.assertTrue(macroRead == TEST_VALUE)
+
+    def test_cnc_sysinfo(self):
+        response = self.focas.cnc_sysinfo()
+        self.assertTrue(response != None)
 
     @classmethod
     def tearDownClass(self):


### PR DESCRIPTION
Changed Ip address to match current machine.  Added Functionality to focas.py to read the cnc_sysinfo.  Added Correct structures to focas_structs.py.  This should be helpful in dynamically understanding functions that are supported by different control types.  Tested on 16I-MB Control. Added test case for cnc_sysinfo. I did not parse out the additional info at this time.  